### PR TITLE
Use exdn instead of erldn for handling edn parsing in the tests. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /deps
 erl_crash.dump
 *.ez
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ movies = Exdn.to_elixir!(body)
 # vector: [17592186045524], vector: [17592186045521]]
 ```
 
+## Related Projects
+
+The [Exdn edn parser library](https://github.com/psfblair/exdn) 
+([API docs](http://hexdocs.pm/exdn/1.0.1/api-reference.html)) may be used with
+Datomex, both to parse incoming edn and to generate edn strings from Elixir data
+structures. Some examples of how this can be done may be found in the tests.
+
 ## TODO
-- Use `exdn` to make working with the data and queries nicer
 - Add docs
+- Tighter integration with `exdn`.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Datomex.entity 1
 
 Datomex.transact(~s([[:db/add #db/id [:db.part/user] :movie/title "trainspotting"]]))
 {:ok, %HTTPoison.Response{ body: body }} = Datomex.q(~s([:find ?m :where [?m :movie/title "trainspotting"]]))
-{:ok, {:vector, movies}} = :erldn.parse_str(String.to_char_list(body))
+movies = Exdn.to_elixir!(body)
 # [vector: [17592186045486], vector: [17592186045538], vector: [17592186045481],
 # vector: [17592186045483], vector: [17592186045478], vector: [17592186045509],
 # vector: [17592186045474], vector: [17592186045468], vector: [17592186045503],
@@ -89,5 +89,5 @@ Datomex.transact(~s([[:db/add #db/id [:db.part/user] :movie/title "trainspotting
 ```
 
 ## TODO
-- Use `erldn` to make working with the data and queries nicer
+- Use `exdn` to make working with the data and queries nicer
 - Add docs

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ movies = Exdn.to_elixir!(body)
 ## Related Projects
 
 The [Exdn edn parser library](https://github.com/psfblair/exdn) 
-([API docs](http://hexdocs.pm/exdn/1.0.1/api-reference.html)) may be used with
+([API docs](http://hexdocs.pm/exdn/2.1.1/api-reference.html)) may be used with
 Datomex, both to parse incoming edn and to generate edn strings from Elixir data
 structures. Some examples of how this can be done may be found in the tests.
 

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Datomex.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger, :httpoison]]
+    [applications: [:logger, :httpoison, :tzdata]]
   end
 
   # Dependencies can be Hex packages:
@@ -35,7 +35,7 @@ defmodule Datomex.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-        {:exdn, "~> 1.0.1"},
+        {:exdn, "~> 2.1.1"},
         {:httpoison, "~> 0.8.0"},
         {:poison, "~> 1.5"},
         {:ex_doc, "~> 0.6.1"}

--- a/mix.exs
+++ b/mix.exs
@@ -3,8 +3,8 @@ defmodule Datomex.Mixfile do
 
   def project do
     [app: :datomex,
-     version: "0.0.5",
-     elixir: "~> 1.0",
+     version: "0.0.6",
+     elixir: "~> 1.2",
      deps: deps,
      package: [
        contributors: ["Eric West"],
@@ -35,9 +35,9 @@ defmodule Datomex.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-        {:erldn, "~> 1.0.2"},
-        {:httpoison, "~> 0.5"},
-        {:poison, "~> 1.2"},
+        {:exdn, "~> 1.0.1"},
+        {:httpoison, "~> 0.8.0"},
+        {:poison, "~> 1.5"},
         {:ex_doc, "~> 0.6.1"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,12 +1,12 @@
 %{"calendar": {:hex, :calendar, "0.12.3"},
   "certifi": {:hex, :certifi, "0.3.0"},
-  "erldn": {:hex, :erldn, "1.0.2"},
+  "erldn": {:hex, :erldn, "1.0.3"},
   "ex_doc": {:hex, :ex_doc, "0.6.1"},
-  "exdn": {:hex, :exdn, "1.0.1"},
+  "exdn": {:hex, :exdn, "2.1.1"},
   "hackney": {:hex, :hackney, "1.4.8"},
   "httpoison": {:hex, :httpoison, "0.8.1"},
   "idna": {:hex, :idna, "1.0.3"},
   "mimerl": {:hex, :mimerl, "1.0.2"},
   "poison": {:hex, :poison, "1.5.2"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
-  "tzdata": {:hex, :tzdata, "0.1.8"}}
+  "tzdata": {:hex, :tzdata, "0.5.6"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,12 @@
-%{"erldn": {:hex, :erldn, "1.0.2"},
+%{"calendar": {:hex, :calendar, "0.12.3"},
+  "certifi": {:hex, :certifi, "0.3.0"},
+  "erldn": {:hex, :erldn, "1.0.2"},
   "ex_doc": {:hex, :ex_doc, "0.6.1"},
-  "hackney": {:hex, :hackney, "0.14.3"},
-  "httpoison": {:hex, :httpoison, "0.5.0"},
-  "idna": {:hex, :idna, "1.0.1"},
-  "poison": {:hex, :poison, "1.2.0"}}
+  "exdn": {:hex, :exdn, "1.0.1"},
+  "hackney": {:hex, :hackney, "1.4.8"},
+  "httpoison": {:hex, :httpoison, "0.8.1"},
+  "idna": {:hex, :idna, "1.0.3"},
+  "mimerl": {:hex, :mimerl, "1.0.2"},
+  "poison": {:hex, :poison, "1.5.2"},
+  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
+  "tzdata": {:hex, :tzdata, "0.1.8"}}


### PR DESCRIPTION
Over the past few days I've created exdn, an Elixir wrapper for erldn that allows working with more natural Elixir data structures. It is a two-way translation -- not only does it parse edn into data structures, but it also generates edn from normal Elixir data structures.

Exdn repo here: https://github.com/psfblair/exdn and hexdocs here: http://hexdocs.pm/exdn/1.0.1/api-reference.html

This commit substitutes exdn for erldn in the datomex tests, showing how it can be used both to parse query results and to create transactions and queries. You'll see that the parsing side is much less verbose, while the query side is more verbose. It may ultimately be better to write edn strings directly rather than creating them from data structures, but this at least demonstrates how it might be done. If you  like the changes to the parsing but prefer not to use exdn for the edn generation part, I can take those out.
